### PR TITLE
(SIMP-1983) Remove simplib dependancy from dirtycow

### DIFF
--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,5 +1,3 @@
 # Drop all Requires, Obsoletes, and Provides statements in here
 Requires: pupmod-puppetlabs-stdlib >= 4.9.0
 Requires: pupmod-puppetlabs-stdlib < 5.0.0
-Requires: pupmod-simp-simplib >= 2.0.0-0
-Requires: pupmod-simp-simplib < 3.0.0-0

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-dirtycow",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "SIMP",
   "summary": "SIMP module checking Dirty Cow Vulnerability",
   "license": "Apache-2.0",
@@ -15,10 +15,6 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.9.0 < 5.0.0"
-    },
-    {
-      "name": "simp/simplib",
-      "version_requirement": ">= 2.0.0 < 3.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
  Simplib is not needed by dirtycow and is preventing
  4.2 from compiling because of different simplib
  versions.  Remove dependancy so we only have one
  version, master.

SIMP-1983  #close